### PR TITLE
ci: 更新 GitHub Actions 工作流中的 JAR 文件路径

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -49,4 +49,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pepperoni-1.21.3
-          path: build/libs/*.jar
+          path: build/libs/pepperoni-1.0.jar


### PR DESCRIPTION
- 修改 .github/workflows/gradle.yml 文件
- 将上传 JAR 文件的路径从 build/libs/*.jar 改为 build/libs/pepperoni-1.0.jar- 此更改确保了在构建产物中上传指定版本的 JAR 文件